### PR TITLE
Use forward-line instead of next-line.

### DIFF
--- a/gcal.el
+++ b/gcal.el
@@ -77,21 +77,21 @@
   "Parse HTTP response in buffer."
   (with-current-buffer buffer
     ;; Response Line (ex: HTTP/1.1 200 OK)
-    (beginning-of-buffer)
+    (goto-char (point-min))
     (if (looking-at "^HTTP/[^ ]+ \\([0-9]+\\) ?\\(.*\\)$")
         (let ((status (string-to-number (match-string 1)))
               (message (match-string 2))
               (headers)
               (body))
-          (next-line)
+          (forward-line)
           ;; Header Lines
           (while (not (eolp))
             (if (looking-at "^\\([^:]+\\): \\(.*\\)$")
                 (push (cons (match-string 1) (match-string 2)) headers))
-            (next-line))
+            (forward-line))
 
           ;; Body
-          (next-line)
+          (forward-line)
           (setq body (buffer-substring (point) (point-max)))
 
           ;; Result


### PR DESCRIPTION
メンテナンスありがとうございます。org-gcalがまともに使えなかったので、とても助かっています。

json-parse-errorがtoken取得時に出てしまい、コードを確認したところ、next-lineが行頭以外に移動することがあるのが原因であることがわかりました。もともとnext-lineはinteractiveでのみ使うよう作られているため、next-lineをforward-lineにしました。

この後他にもいくつか機能追加のPRを送ると思いますが、お時間のあるときに見ていただけると嬉しいです。