### PR TITLE
Let parental header included by summary.

### DIFF
--- a/gcal-org.el
+++ b/gcal-org.el
@@ -695,7 +695,8 @@ old-events will be destroyed."
        . ((private
            . (,@(if ts-prefix `((gcalTsPrefix . ,ts-prefix)))
               (gcalOrd . ,ord)
-              ,@(when summary-prefix `((gcalSummaryPrefix . ,summary-prefix)))))))
+              ,@(when (string-empty-p summary-prefix)
+                  `((gcalSummaryPrefix . ,summary-prefix)))))))
       ,@(if location `((location . ,location)))
       )))
 
@@ -738,8 +739,8 @@ old-events will be destroyed."
        :id id
        :ord ord
        :summary
-       (if (eq 0 (string-match (regexp-quote summary-prefix) summary))
-           (substring summary (match-end 0))
+       (if (string-prefix-p summary-prefix summary)
+           (string-remove-prefix summary-prefix summary)
          (display-warning
           :error
           (format "gcal.el: parental path of summary has changed:
@@ -751,7 +752,7 @@ old-events will be destroyed."
        :ts-start ts-start
        :ts-end (gcal-ts-end-inclusive ts-start ts-end)
        :location location
-       :summary-prefix summary-prefix
+       :summary-prefix (or summary-prefix "")
        )))))
 
 

--- a/gcal-org.el
+++ b/gcal-org.el
@@ -116,10 +116,12 @@
                             (plist-get ts :minute-end)))
                (same-entry-info  (assoc id entries))
                (same-entry-count (length (nth 1 same-entry-info)))
-               (summary-prefix (gcal-org-make-summary-prefix
-                                (org-get-outline-path)
-                                gcal-org-header-separator
-                                gcal-org-include-parents-header-maximum))
+               (summary-prefix (if (eq gcal-org-include-parents-header-maximum 0)
+                                   ""
+                                 (gcal-org-make-summary-prefix
+                                  (org-get-outline-path)
+                                  gcal-org-header-separator
+                                  gcal-org-include-parents-header-maximum)))
                (oevent      (make-gcal-oevent
                              :id id
                              :ord same-entry-count

--- a/gcal-org.el
+++ b/gcal-org.el
@@ -60,13 +60,13 @@
   "イベントのsummaryに何階層上までのヘッダを含めるかを表します。
 `t'は全ての親階層を含めることを表します。"
   :group 'gcal
-  :type '(choice number (const t)))
+  :type '(choice integer (const t)))
 
 (defcustom gcal-org-header-separator "/"
   "`gcal-org-include-parents-header-maximum'が0でないときに、
 イベントのsummaryにおいてヘッダを隔てる文字列を表わします。"
   :group 'gcal
-  :type '(choice number (const t)))
+  :type 'string)
 
 ;;
 ;; Parse org-mode document
@@ -151,7 +151,7 @@ HEADER-MAXIMUMの深さまで、PATHをSEPARATORで繋げます。"
   (string-join
    (append
     (nthcdr
-     (if (numberp header-maximum)
+     (if (integerp header-maximum)
          (max
           (- (length path) header-maximum)
           0)
@@ -636,7 +636,7 @@ old-events will be destroyed."
          (path-str (apply #'concat
                           (mapcan (lambda (elt) (list elt separator))
                                   (nthcdr
-                                   (if (numberp header-maximum)
+                                   (if (integerp header-maximum)
                                        (max
                                         (- (length path) header-maximum)
                                         0)

--- a/gcal-org.el
+++ b/gcal-org.el
@@ -722,7 +722,7 @@ old-events will be destroyed."
          (ex-prop-ts-prefix (cdr (assq 'gcalTsPrefix ex-props)))
          (created-on-google (and (null ex-prop-ord) (null ex-prop-ts-prefix)))
          (ts-prefix (if created-on-google "SCHEDULED" ex-prop-ts-prefix))
-         (summary-prefix (cdr (assq 'gcalSummaryPrefix ex-props)))
+         (summary-prefix (or (cdr (assq 'gcalSummaryPrefix ex-props)) ""))
          ;; Strip DL:
          (summary
           (if (and (stringp ts-prefix)
@@ -754,7 +754,7 @@ old-events will be destroyed."
        :ts-start ts-start
        :ts-end (gcal-ts-end-inclusive ts-start ts-end)
        :location location
-       :summary-prefix (or summary-prefix "")
+       :summary-prefix summary-prefix
        )))))
 
 

--- a/gcal-org.el
+++ b/gcal-org.el
@@ -3,7 +3,7 @@
 ;; Copyright (C) 2016  AKIYAMA Kouhei
 
 ;; Author: AKIYAMA Kouhei <misohena@gmail.com>
-;; Keywords: 
+;; Keywords:
 
 ;; This program is free software; you can redistribute it and/or modify
 ;; it under the terms of the GNU General Public License as published by
@@ -53,6 +53,17 @@
   :group 'gcal
   :type '(repeat (choice (const "SCHEDULED") (const "DEADLINE") (const nil))))
 
+(defcustom gcal-org-include-parents-header-maximum 0
+  "イベントのsummaryに何階層上までのヘッダを含めるかを表します。
+`t'は全ての親階層を含めることを表します。"
+  :group 'gcal
+  :type '(choice number (const t)))
+
+(defcustom gcal-org-header-separator "/"
+  "`gcal-org-include-parents-header-maximum'が0でないときに、
+イベントのsummaryにおいてヘッダを隔てる文字列を表わします。"
+  :group 'gcal
+  :type '(choice number (const t)))
 
 ;;
 ;; Parse org-mode document
@@ -87,7 +98,19 @@
                ;; ID is not needed when ts-prefix is not allowed.
                (id         (when ts-prefix-allowed (org-id-get-create))) ;; change (point)
                (location   (org-entry-get (point) "LOCATION"))
-               (summary    (substring-no-properties (org-get-heading t t)))
+               (summary
+                (string-join
+                 (let ((path (org-get-outline-path)))
+                   (append
+                    (nthcdr
+                    (if (numberp gcal-org-include-parents-header-maximum)
+                        (max
+                         (- (length path) gcal-org-include-parents-header-maximum)
+                         0)
+                      0)
+                    path)
+                    (list (org-get-heading t t))))
+                 gcal-org-header-separator))
                (ts         (cadr (org-element-timestamp-parser)))
                (ts-end-pos (plist-get ts :end))
                (ts-start   (list

--- a/gcal-org.el
+++ b/gcal-org.el
@@ -98,19 +98,11 @@
                ;; ID is not needed when ts-prefix is not allowed.
                (id         (when ts-prefix-allowed (org-id-get-create))) ;; change (point)
                (location   (org-entry-get (point) "LOCATION"))
-               (summary
-                (string-join
-                 (let ((path (org-get-outline-path)))
-                   (append
-                    (nthcdr
-                    (if (numberp gcal-org-include-parents-header-maximum)
-                        (max
-                         (- (length path) gcal-org-include-parents-header-maximum)
-                         0)
-                      0)
-                    path)
-                    (list (org-get-heading t t))))
-                 gcal-org-header-separator))
+               (summary (gcal-org-make-oevent-summary
+                         (substring-no-properties (org-get-heading t t))
+                         (org-get-outline-path)
+                         gcal-org-header-separator
+                         gcal-org-include-parents-header-maximum))
                (ts         (cadr (org-element-timestamp-parser)))
                (ts-end-pos (plist-get ts :end))
                (ts-start   (list
@@ -146,6 +138,21 @@
             (push oevent events))
           (goto-char ts-end-pos)))
       (nreverse events))))
+
+(defun gcal-org-make-oevent-summary (heading path separator header-maximum)
+  "oeventのサマリーを生成します。
+HEADER-MAXIMUMの深さまで、PATHをSEPARATORで繋げます。"
+  (string-join
+   (append
+    (nthcdr
+     (if (numberp header-maximum)
+         (max
+          (- (length path) header-maximum)
+          0)
+       0)
+     path)
+    (list heading))
+   separator))
 
 
 

--- a/gcal-org.el
+++ b/gcal-org.el
@@ -697,7 +697,7 @@ old-events will be destroyed."
        . ((private
            . (,@(if ts-prefix `((gcalTsPrefix . ,ts-prefix)))
               (gcalOrd . ,ord)
-              ,@(when (string-empty-p summary-prefix)
+              ,@(when (not (string-empty-p summary-prefix))
                   `((gcalSummaryPrefix . ,summary-prefix)))))))
       ,@(if location `((location . ,location)))
       )))


### PR DESCRIPTION
org-modeで予定やタスクを管理する場合、親ヘッダも含めて意味を持つことがよくあると思います。
```org-mode
* 本の名前
** 1章
*** 1節
```
このような場合、親ヘッダも含めてgoogle Calendarに予定登録できるといいなあと思い、機能を追加してみました。
