### PR TITLE
Add timestamp range when pushing.

### DIFF
--- a/gcal-org.el
+++ b/gcal-org.el
@@ -46,6 +46,13 @@
 (defun gcal-oevent-ts-end (oevent) (plist-get oevent :ts-end))
 (defun gcal-oevent-location (oevent) (plist-get oevent :location))
 
+(defcustom gcal-org-allowed-timestamp-prefix '(nil "SCHEDULED" "DEADLINE")
+  "パースする際にイベントとみなされるタイムスタンプの接頭辞を持ちます。
+ここに含まれない接頭辞のついたタイムスタンプは無視され、イベントとして扱われません。
+`nil'は接尾辞なしを表わします。"
+  :group 'gcal
+  :type '(repeat (choice (const "SCHEDULED") (const "DEADLINE") (const nil))))
+
 
 ;;
 ;; Parse org-mode document
@@ -76,7 +83,9 @@
         (goto-char (match-beginning 0))
         (let* ((ts-prefix  (if (looking-back "\\(SCHEDULED\\|DEADLINE\\): *")
                                (match-string-no-properties 1)))
-               (id         (org-id-get-create)) ;; change (point)
+               (ts-prefix-allowed (member ts-prefix gcal-org-allowed-timestamp-prefix))
+               ;; ID is not needed when ts-prefix is not allowed.
+               (id         (when ts-prefix-allowed (org-id-get-create))) ;; change (point)
                (location   (org-entry-get (point) "LOCATION"))
                (summary    (substring-no-properties (org-get-heading t t)))
                (ts         (cadr (org-element-timestamp-parser)))
@@ -105,12 +114,13 @@
                              :location location))
                )
 
-          (when (null same-entry-info)  ;; New ID found
-            (setq same-entry-info (list id nil))
-            (push same-entry-info entries))
+          (when ts-prefix-allowed
+            (when (null same-entry-info)  ;; New ID found
+              (setq same-entry-info (list id nil))
+              (push same-entry-info entries))
 
-          (push oevent (nth 1 same-entry-info))
-          (push oevent events)
+            (push oevent (nth 1 same-entry-info))
+            (push oevent events))
           (goto-char ts-end-pos)))
       (nreverse events))))
 


### PR DESCRIPTION
せっかく一段落ついたところにすみません。
やはりファイルにタイムスタンプが大量にあるとpushが重いので、日時の範囲指定ができるような拡張を作成しました。(いずれはasync化するのもよいかもしれないです)

現状で動くことには動くのですが、以下のような不具合(？)があります。
- pushのときにcacheも指定範囲のもので保存されるため、pullのときに実際には既に存在するイベントが存在しないと判定されてaddへと振り分けられ、"Event is already exist" が出ます(出るだけで破壊的な実害はないですが、そもそもpullしているのにヘッダが更新されないという問題があります)。
- parseのときにoeventを選り分けることで実装しているのですが、そのままキャッシュとの差分(diff)をとると範囲外のものが全て削除されてしまうため、キャッシュも範囲内に削ってからdiffしています。この実装の問題として、timestampに範囲を跨ぐ変更があった場合に変な挙動を示す可能性があるかもしれません(おそらく範囲を出た場合は単にpushされず、範囲に入った場合は(キャッシュが存在しないので)問答無用でpushされるだけ(タイムスタンプが変更を受けているのでpushされるのが正常)、となっているはず(試した限りではそうだった)ですが、少し心配)。

これらも含め、見ていただけると嬉しいです。

P.S. これ以上私にはアイデアがないので、直接このPRにcommitしていただいても構いません。