### PR TITLE
Out of range bug fix.

### DIFF
--- a/gcal-org.el
+++ b/gcal-org.el
@@ -1227,7 +1227,8 @@ RECURRENCEがnilの場合、リピーターがないタイムスタンプで表�
   (save-excursion
     (if (integerp ts-end)
         (goto-char ts-end))
-    (when (string= (buffer-substring-no-properties (point) (+ (point) 2))
+    (when (string= (buffer-substring-no-properties (point)
+                                                   (min (+ (point) 2) (point-max)))
                    "#(")
       (goto-char (1+ (point)))
       (save-restriction


### PR DESCRIPTION
最近頻繁に更新されていて、嬉しいです。メンテナンスありがとうございます。

ファイルの最後にタイムスタンプがあると、存在しないpointにアクセスしてしまってout of rangeエラーを吐くので、暫定的に修正しました。1行しか変更してませんのでそんなにお手間は取らせないと思います。