### PR TITLE
Add package meta information

### DIFF
--- a/gcal-id.el
+++ b/gcal-id.el
@@ -3,7 +3,7 @@
 ;; Copyright (C) 2016  AKIYAMA Kouhei
 
 ;; Author: AKIYAMA Kouhei <misohena@gmail.com>
-;; Keywords: 
+;; URL: https://github.com/misohena/gcal
 
 ;; This program is free software; you can redistribute it and/or modify
 ;; it under the terms of the GNU General Public License as published by

--- a/gcal-org.el
+++ b/gcal-org.el
@@ -3,7 +3,10 @@
 ;; Copyright (C) 2016  AKIYAMA Kouhei
 
 ;; Author: AKIYAMA Kouhei <misohena@gmail.com>
-;; Keywords:
+;; Version: 0.9.0
+;; Keywords: convenience
+;; Package-Requires: ((emacs "26.3"))
+;; URL: https://github.com/misohena/gcal
 
 ;; This program is free software; you can redistribute it and/or modify
 ;; it under the terms of the GNU General Public License as published by

--- a/gcal.el
+++ b/gcal.el
@@ -3,7 +3,10 @@
 ;; Copyright (C) 2016  AKIYAMA Kouhei
 
 ;; Author: AKIYAMA Kouhei <misohena@gmail.com>
-;; Keywords: 
+;; Version: 0.9.0
+;; Keywords: convenience
+;; Package-Requires: ((emacs "26.3"))
+;; URL: https://github.com/misohena/gcal
 
 ;; This program is free software; you can redistribute it and/or modify
 ;; it under the terms of the GNU General Public License as published by


### PR DESCRIPTION
#10 に関連の作業です。

ヘッダー情報を追加しました。

とりあえずバージョンはv0.9としました。MELPAに公開したらv1.0となる
想定ですが、この辺は好みだと思いますがどうでしょう。。？

また、Emacsの要求バージョンは仮定として26.3を指定しました。
現状 `if-let` により25.1は必要のようですが、26.3を指定することに
より、(経験上)メンテナンスが簡単になります。

パッケージはgcalとgcal-orgで分けて登録することを想定しています。
gcal-idはgcal-orgと同じパッケージに入れることを想定していますが、
短かいのでgcal-orgに入れてしまうのが良いかもしれません。